### PR TITLE
支持设定是否在启动时打开浏览器（BILIDOWN_STARTUP_OPEN_BROWSER）

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -46,7 +46,9 @@ func onReady() {
 	mustRunServer()
 	// 调用默认浏览器访问端口
 	time.Sleep(time.Millisecond * 1000)
-	openBrowser(urlLocalUnix)
+	if os.Getenv("BILIDOWN_STARTUP_OPEN_BROWSER") != "false" {
+		openBrowser(urlLocalUnix)
+	}
 	// 保持运行
 	select {}
 }


### PR DESCRIPTION
添加环境变量 `BILIDOWN_STARTUP_OPEN_BROWSER`，默认情况下仍然于启动时打开浏览器（与先前保持一致），而当此值为 `false` 时则不再于启动时打开浏览器。